### PR TITLE
Fixed bug where credentials specified on the CLI caused the run to error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.1.1
+
+Fix bug with credentials lookup
+
 ## v0.1.0
 
 Initial Revision

--- a/actions/lib/bolt.py
+++ b/actions/lib/bolt.py
@@ -183,8 +183,10 @@ class BoltAction(Action):
         return (success, stdout)
 
     def run(self, **kwargs):
-        kwargs = self.resolve_config(**kwargs)
+        # resolve credentials first so that creds from the CLI override
+        # credentials in the config
         kwargs = self.resolve_credentials(**kwargs)
+        kwargs = self.resolve_config(**kwargs)
 
         cmd = kwargs['cmd']
         sub_command = kwargs['sub_command']

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - remote execution
     - configuration management
     - cfg management
-version: 0.1.0
+version: 0.1.1
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION
Found a bug when not specifying a `credentials` parameter and trying to explicitly override it with a `user` or `password`, then the action would error.

This fixes the bug by resolving credentials from the CLI first, then parsing data from the config.

Tests were also added to check for this scenario in the future.