### PR TITLE
Bugfix for using params_obj vs params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.1.2
+
+Fix bug with passing params through params_obj variable
+
 ## v0.1.1
 
 Fix bug with credentials lookup

--- a/actions/lib/bolt.py
+++ b/actions/lib/bolt.py
@@ -130,8 +130,8 @@ class BoltAction(Action):
 
         # if params_obj is sepcified, convert it into JSON
         # only do this if 'params' was not specified ('params' overrides 'params_obj')
-        if 'params_obj' in kwargs:
-            if 'params' not in kwargs:
+        if kwargs.get('params_obj'):
+            if not kwargs.get('params'):
                 kwargs['params'] = json.dumps(kwargs['params_obj'])
             del kwargs['params_obj']
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - remote execution
     - configuration management
     - cfg management
-version: 0.1.1
+version: 0.1.2
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_bolt.py
+++ b/tests/test_action_lib_bolt.py
@@ -175,6 +175,21 @@ class TestActionLibBolt(BoltBaseActionTestCase):
         self.assertEquals(args, [])
         self.assertEquals(options, ['--params', '{"test": "value"}'])
 
+    # Test that params_obj get set properly when params is None
+    def test_build_options_args_params_none(self):
+        action = self.get_action_instance({})
+        options, args = action.build_options_args(params_obj={'test': 'value'},
+                                                  params=None)
+        self.assertEquals(args, [])
+        self.assertEquals(options, ['--params', '{"test": "value"}'])
+
+    # Test that params doesn't get overwritten when params_obj is None
+    @mock.patch("lib.bolt.json.dumps")
+    def test_build_options_args_params_obj_none(self, mock_json_dumps):
+        action = self.get_action_instance({})
+        options, args = action.build_options_args(params_obj=None)
+        assert not mock_json_dumps.called
+
     def test_build_options_args_params_overrides_params_obj_json(self):
         action = self.get_action_instance({})
         options, args = action.build_options_args(params_obj={'test': 'value'},


### PR DESCRIPTION
When using `params_obj` input and not passing any `params`, the `params` option is still specified but with the value of `None`.

The code was processing this scenario incorrectly. This fixes the problem.