### PR TITLE
Added color option. Added three new actions. Fixed JSON parsing bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,34 @@
 # Change Log
 
+## v0.2.0
+
+* Add `color` as an option for this pack's config and a parameter to all actions.
+  By default, color output is `false` (disabled) to make it easier to parse Bolt's output.
+  This can be changed globally in the pack's config, or on any individual action when
+  invoking it.
+  
+* Previously, this pack would always try to parse the `stdout` of every Bolt run as if it
+  had JSON data in it. This caused false exceptions when the user passed in `format='human'`.
+  This pack now skips JSON parsing of `stdout` if `format='human'`.
+  
+* Added a new action `bolt.apply` that applies a Puppet manifest file (`.pp`) on a set of nodes.
+
+* Added a new action `bolt.puppetfile_show_modules` that lists all modules available to Bolt.
+
+* Added a new action `bolt.version` that returns the version of Bolt that is installed.
+
 ## v0.1.3
 
-Fix bug with passing empty params_obj variable
+* Fix bug with passing empty params_obj variable
 
 ## v0.1.2
 
-Fix bug with passing params through params_obj variable
+* Fix bug with passing params through params_obj variable
 
 ## v0.1.1
 
-Fix bug with credentials lookup
+* Fix bug with credentials lookup
 
 ## v0.1.0
 
-Initial Revision
+* Initial Revision

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ documentation.
 * `tty` - Request a pseudo TTY on nodes that support it
 * `tmpdir` - The directory to upload and execute temporary files on the target
 * `format` - Output format to use: human or json [default = `json`]
+* `color` - Whether to show output in color
 * `verbose` - Display verbose logging
 * `debug_` - Display debug logging
 * `trace` - Display error stack traces
@@ -145,6 +146,7 @@ CLI command.
 
 Below is a list of currently available actions:
 
+* `bolt.apply` - Apply Puppet manifest code.
 * `bolt.command_run` - Runs a command remotely.
 * `bolt.file_upload` - Upload local file `src` to `dest` on each node.
 * `bolt.install` - Installs Bolt on the StackStorm node.
@@ -152,11 +154,22 @@ Below is a list of currently available actions:
 * `bolt.plan_run` - Run a Puppet task plan.
 * `bolt.plan_show` - Show details for plan.
 * `bolt.puppetfile_install` - Install modules from a Puppetfile into a Boltdir.
+* `bolt.puppetfile_show_modules` - List modules available to Bolt
 * `bolt.script_run` - Upload a local script and run it remotely.
 * `bolt.task_list` - Show list of available tasks.
 * `bolt.task_run` - Run a Puppet task.
 * `bolt.task_show` - Show documentation for task.
 
+
+### Action Example - bolt.apply
+
+`bolt.apply` is used to apply a Puppet manifest file on remote hosts using the Puppet agent.
+The `manifest` parameter is the path to the manifest file on the StackStorm host that will
+be uploaded to the remote nodes and applied with the Puppet agent.
+
+``` shell
+st2 run bolt.apply manifest="/etc/puppetlabs/code/test.pp" nodes=host1.domain.tld
+```
 
 ### Action Example - bolt.command_run
 
@@ -252,6 +265,14 @@ modules into `/custom/data/modules` I would run:
 st2 run bolt.puppetfile_install boltdir='/custom/data` modulepath='/custom/data/modules`
 ```
 
+### Action Example - bolt.puppetfile_show_modules
+
+`bolt.puppetfile_show_modules` shows all of the available Puppet modules in Bolt's `modulepath`.
+
+``` shell
+st2 run bolt.puppetfile_show_modules modulepath='/custom/data/modules`
+```
+
 ### Action Example - bolt.script_run
 
 `bolt.script_run` uploads a local script, specified by the `script` paramter, from the
@@ -283,6 +304,14 @@ st2 run bolt.task_run task="service::linux" params='name=rsyslog action=restart'
 
 ``` shell
 st2 run bolt.task_show task="service::linux"
+```
+
+### Action Example - bolt.version
+
+`bolt.version` returns the version of Bolt installed on the StackStorm node.
+
+``` shell
+st2 run bolt.version"
 ```
 
 ## Aliases

--- a/actions/apply.yaml
+++ b/actions/apply.yaml
@@ -1,7 +1,7 @@
 ---
-description: "Install modules from a Puppetfile into a Boltdir"
+description: "Apply Puppet manifest code."
 enabled: true
-name: puppetfile_install
+name: apply
 pack: bolt
 runner_type: python-script
 entry_point: lib/bolt.py
@@ -9,7 +9,11 @@ parameters:
   sub_command:
     type: string
     immutable: true
-    default: "puppetfile install"
+    default: "apply"
+  manifest:
+    type: string
+    description: "Path to a manifest file (.pp) to upload and apply on a set of nodes"
+    required: true
   ### Begin common environment
   cwd:
     type: string

--- a/actions/command_run.yaml
+++ b/actions/command_run.yaml
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/file_upload.yaml
+++ b/actions/file_upload.yaml
@@ -129,6 +129,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/lib/bolt.py
+++ b/actions/lib/bolt.py
@@ -163,16 +163,18 @@ class BoltAction(Action):
                 args.append(v)
         return options, args
 
-    def execute(self, cmd, sub_command, options, args, env, cwd):
+    def execute(self, cmd, sub_command, options, args, env, cwd, format):
         full_cmd = [cmd] + sub_command.split(' ') + options + args
-        # self.logger.debug(' '.join(full_cmd))
         process = subprocess.Popen(full_cmd,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
                                    env=env,
                                    cwd=cwd)
         stdout, stderr = process.communicate()
-        if stdout:
+        # only try to parse JSON when the requested output format is JSON
+        # if it's 'human' format, then skip JSON parsing to avoid the unecessary
+        # exceptions
+        if stdout and format == 'json':
             try:
                 stdout = json.loads(stdout)
             except Exception as e:
@@ -193,6 +195,7 @@ class BoltAction(Action):
 
         cmd = kwargs['cmd']
         sub_command = kwargs['sub_command']
+        format = kwargs['format']
         # inherit from OS environment by default
         env = os.environ.copy()
         # merge in any environment variables set as action arguments
@@ -200,4 +203,4 @@ class BoltAction(Action):
         cwd = kwargs.get('cwd', None)
 
         options, args = self.build_options_args(**kwargs)
-        return self.execute(cmd, sub_command, options, args, env, cwd)
+        return self.execute(cmd, sub_command, options, args, env, cwd, format)

--- a/actions/plan_list.yaml
+++ b/actions/plan_list.yaml
@@ -111,6 +111,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/plan_run.yaml
+++ b/actions/plan_run.yaml
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/plan_show.yaml
+++ b/actions/plan_show.yaml
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/puppetfile_show_modules.yaml
+++ b/actions/puppetfile_show_modules.yaml
@@ -1,7 +1,7 @@
 ---
-description: "Install modules from a Puppetfile into a Boltdir"
+description: "List modules available to Bolt"
 enabled: true
-name: puppetfile_install
+name: puppetfile_show_modules
 pack: bolt
 runner_type: python-script
 entry_point: lib/bolt.py
@@ -9,7 +9,7 @@ parameters:
   sub_command:
     type: string
     immutable: true
-    default: "puppetfile install"
+    default: "puppetfile show-modules"
   ### Begin common environment
   cwd:
     type: string

--- a/actions/script_run.yaml
+++ b/actions/script_run.yaml
@@ -12,7 +12,7 @@ parameters:
     default: "script run"
   script:
     type: string
-    description: "The script to upload and run"
+    description: "Path to the script to upload and run on a set of nodes"
     required: true
   ### Begin common environment
   cwd:
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/task_list.yaml
+++ b/actions/task_list.yaml
@@ -111,6 +111,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/task_run.yaml
+++ b/actions/task_run.yaml
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/task_show.yaml
+++ b/actions/task_show.yaml
@@ -115,6 +115,9 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+  color:
+    type: boolean
+    description: "Whether to show output in color"
   verbose:
     type: boolean
     description: "Display verbose logging"

--- a/actions/version.yaml
+++ b/actions/version.yaml
@@ -1,7 +1,7 @@
 ---
-description: "Install modules from a Puppetfile into a Boltdir"
+description: "List the version of Bolt installed."
 enabled: true
-name: puppetfile_install
+name: version
 pack: bolt
 runner_type: python-script
 entry_point: lib/bolt.py
@@ -9,7 +9,7 @@ parameters:
   sub_command:
     type: string
     immutable: true
-    default: "puppetfile install"
+    default: "--version"
   ### Begin common environment
   cwd:
     type: string
@@ -111,6 +111,7 @@ parameters:
   format:
     type: string
     description: "Output format to use: human or json"
+    default: "human"
   color:
     type: boolean
     description: "Whether to show output in color"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -50,6 +50,10 @@ tty:
 tmpdir:
   type: string
   description: "The directory to upload and execute temporary files on the target"
+color:
+  type: boolean
+  description: "Whether to show output in color"
+  default: false
 format:
   type: string
   description: "Output format to use: human or json"

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - remote execution
     - configuration management
     - cfg management
-version: 0.1.3
+version: 0.2.0
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_bolt.py
+++ b/tests/test_action_lib_bolt.py
@@ -370,7 +370,8 @@ class TestActionLibBolt(BoltBaseActionTestCase):
                                 ['--verbose'],
                                 ['data=something'],
                                 {'BOLT_TEST': 'Value'},
-                                '/opt/stackstorm')
+                                '/opt/stackstorm',
+                                'json')
 
         self.assertEquals(result, (True, {"stdout": "value"}))
         mock_popen.assert_called_with(['/opt/puppetlabs/bin/bolt',
@@ -401,7 +402,8 @@ class TestActionLibBolt(BoltBaseActionTestCase):
                                 ['--verbose'],
                                 ['data=something'],
                                 {'BOLT_TEST': 'Value'},
-                                '/opt/stackstorm')
+                                '/opt/stackstorm',
+                                'json')
 
         self.assertEquals(result, (False, {"stdout": "data"}))
         mock_popen.assert_called_with(['/opt/puppetlabs/bin/bolt',
@@ -432,7 +434,8 @@ class TestActionLibBolt(BoltBaseActionTestCase):
                                 ['--verbose'],
                                 ['data=something'],
                                 {'BOLT_TEST': 'Value'},
-                                '/opt/stackstorm')
+                                '/opt/stackstorm',
+                                'json')
 
         self.assertEquals(result, (True, 'not JSON data'))
         mock_popen.assert_called_with(['/opt/puppetlabs/bin/bolt',
@@ -447,6 +450,39 @@ class TestActionLibBolt(BoltBaseActionTestCase):
         mock_process.communicate.assert_called_with()
         mock_process.poll.assert_called_with()
         self.assertEquals(action.logger.exception.call_count, 1)
+
+    @mock.patch('subprocess.Popen')
+    def test_execute_format_human(self, mock_popen):
+        action = self.get_action_instance({})
+        action.logger = mock.MagicMock()
+
+        mock_process = mock.MagicMock()
+        mock_process.communicate.return_value = ('not JSON data', '')
+        mock_process.poll.return_value = 0
+
+        mock_popen.return_value = mock_process
+
+        result = action.execute('/opt/puppetlabs/bin/bolt',
+                                'plan run',
+                                ['--verbose'],
+                                ['data=something'],
+                                {'BOLT_TEST': 'Value'},
+                                '/opt/stackstorm',
+                                'human')
+
+        self.assertEquals(result, (True, 'not JSON data'))
+        mock_popen.assert_called_with(['/opt/puppetlabs/bin/bolt',
+                                       'plan',
+                                       'run',
+                                       '--verbose',
+                                       'data=something'],
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE,
+                                      env={'BOLT_TEST': 'Value'},
+                                      cwd='/opt/stackstorm')
+        mock_process.communicate.assert_called_with()
+        mock_process.poll.assert_called_with()
+        self.assertEquals(action.logger.exception.call_count, 0)
 
     @mock.patch('lib.bolt.os.environ.copy')
     @mock.patch('lib.bolt.BoltAction.execute')
@@ -468,17 +504,20 @@ class TestActionLibBolt(BoltBaseActionTestCase):
                             env={'BOLT_TEST': 'Data'},
                             cwd='/opt/stackstorm',
                             params_obj={"input": "some data"},
-                            plan='st2::deploy')
+                            plan='st2::deploy',
+                            format='json')
 
         self.assertEquals(result, (True, {'mydata': 'xxx'}))
         mock_execute.assert_called_with('/opt/puppetlabs/bin/bolt',
                                         'plan run',
-                                        ['--params', '{"input": "some data"}',
+                                        ['--format', 'json',
+                                         '--params', '{"input": "some data"}',
                                          '--private-key', '/home/stanley/.ssh/id_rsa'],
                                         ['st2::deploy'],
                                         {'BOLT_TEST': 'Data',
                                          'INHERITED': 'true'},
-                                        '/opt/stackstorm')
+                                        '/opt/stackstorm',
+                                        'json')
 
     @mock.patch('lib.bolt.os.environ.copy')
     @mock.patch('lib.bolt.BoltAction.execute')
@@ -501,15 +540,18 @@ class TestActionLibBolt(BoltBaseActionTestCase):
                             params_obj={"input": "some data"},
                             plan='st2::deploy',
                             user='cli_user',
-                            password='cli_password')
+                            password='cli_password',
+                            format='human')
 
         self.assertEquals(result, (True, {'mydata': 'xxx'}))
         mock_execute.assert_called_with('/opt/puppetlabs/bin/bolt',
                                         'plan run',
-                                        ['--params', '{"input": "some data"}',
+                                        ['--format', 'human',
+                                         '--params', '{"input": "some data"}',
                                          '--password', 'cli_password',
                                          '--user', 'cli_user'],
                                         ['st2::deploy'],
                                         {'BOLT_TEST': 'Data',
                                          'INHERITED': 'true'},
-                                        '/opt/stackstorm')
+                                        '/opt/stackstorm',
+                                        'human')


### PR DESCRIPTION
* Add `color` as an option for this pack's config and a parameter to all actions.
  By default, color output is `false` (disabled) to make it easier to parse Bolt's output.
  This can be changed globally in the pack's config, or on any individual action when
  invoking it.
  
* Previously, this pack would always try to parse the `stdout` of every Bolt run as if it
  had JSON data in it. This caused false exceptions when the user passed in `format='human'`.
  This pack now skips JSON parsing of `stdout` if `format='human'`.
  
* Added a new action `bolt.apply` that applies a Puppet manifest file (`.pp`) on a set of nodes.

* Added a new action `bolt.puppetfile_show_modules` that lists all modules available to Bolt.

* Added a new action `bolt.version` that returns the version of Bolt that is installed.
