### PR TITLE
Bugfix - Non-string parameters were not being passed correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,25 @@
 # Change Log
 
+## v0.1.4
+
+* Fix bug where non-string parameters such as `connection_timeout` and `concurrency` were
+  causing errors when running the `bolt` command. Non-string parameters will now be
+  cast to a string so that the command invocation library can handle them properly.
+  
+  Contributed by Nick Maludy (Encore Technologies).
+
 ## v0.1.3
 
-Fix bug with passing empty params_obj variable
+* Fix bug with passing empty params_obj variable
 
 ## v0.1.2
 
-Fix bug with passing params through params_obj variable
+* Fix bug with passing params through params_obj variable
 
 ## v0.1.1
 
-Fix bug with credentials lookup
+* Fix bug with credentials lookup
 
 ## v0.1.0
 
-Initial Revision
+* Initial Revision

--- a/actions/lib/bolt.py
+++ b/actions/lib/bolt.py
@@ -157,10 +157,10 @@ class BoltAction(Action):
                     options.append('--no-{}'.format(k_formatted))
             elif k in BOLT_OPTIONS or k in BOLT_CREDENTIALS_OPTIONS:
                 options.append('--{}'.format(k_formatted))
-                options.append(v)
+                options.append(str(v))
             else:
                 # assume it's an argument since it wasn't any of the options above
-                args.append(v)
+                args.append(str(v))
         return options, args
 
     def execute(self, cmd, sub_command, options, args, env, cwd):

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - remote execution
     - configuration management
     - cfg management
-version: 0.1.3
+version: 0.1.4
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_bolt.py
+++ b/tests/test_action_lib_bolt.py
@@ -162,10 +162,10 @@ class TestActionLibBolt(BoltBaseActionTestCase):
         # test that it strips trailing _
         self.assertEquals(action.format_option('x_y_z_'), 'x-y-z')
 
-    def test_build_options_args_src_dst_args(self):
+    def test_build_options_args_src_dest_args(self):
         action = self.get_action_instance({})
         options, args = action.build_options_args(src='local://localhost',
-                                                  dst='ssh://stackstorm.domain.tld')
+                                                  dest='ssh://stackstorm.domain.tld')
         self.assertEquals(args, ['local://localhost', 'ssh://stackstorm.domain.tld'])
         self.assertEquals(options, [])
 
@@ -202,7 +202,7 @@ class TestActionLibBolt(BoltBaseActionTestCase):
     def test_build_options_args_params_overrides_params_obj_json(self):
         action = self.get_action_instance({})
         options, args = action.build_options_args(params_obj={'test': 'value'},
-                                          params='p=xxx')
+                                                  params='p=xxx')
         self.assertEquals(args, [])
         self.assertEquals(options, ['--params', 'p=xxx'])
 
@@ -315,14 +315,14 @@ class TestActionLibBolt(BoltBaseActionTestCase):
             description='description',
             params='params',
             params_obj='params_obj',
-            concurrency='concurrency',
-            compile_concurrency='compile_concurrency',
+            concurrency=12,
+            compile_concurrency=100,
             modulepath='modulepath',
             boltdir='boltdir',
             configfile='configfile',
             inventoryfile='inventoryfile',
             transport='transport',
-            connect_timeout='connect_timeout',
+            connect_timeout=99,
             tmpdir='tmpdir',
             format='format',
             # credentials options
@@ -337,14 +337,14 @@ class TestActionLibBolt(BoltBaseActionTestCase):
         self.assert_remove_option(options, '--query', 'query')
         self.assert_remove_option(options, '--description', 'description')
         self.assert_remove_option(options, '--params', 'params')
-        self.assert_remove_option(options, '--concurrency', 'concurrency')
-        self.assert_remove_option(options, '--compile-concurrency', 'compile_concurrency')
+        self.assert_remove_option(options, '--concurrency', '12')
+        self.assert_remove_option(options, '--compile-concurrency', '100')
         self.assert_remove_option(options, '--modulepath', 'modulepath')
         self.assert_remove_option(options, '--boltdir', 'boltdir')
         self.assert_remove_option(options, '--configfile', 'configfile')
         self.assert_remove_option(options, '--inventoryfile', 'inventoryfile')
         self.assert_remove_option(options, '--transport', 'transport')
-        self.assert_remove_option(options, '--connect-timeout', 'connect_timeout')
+        self.assert_remove_option(options, '--connect-timeout', '99')
         self.assert_remove_option(options, '--tmpdir', 'tmpdir')
         self.assert_remove_option(options, '--format', 'format')
         self.assert_remove_option(options, '--user', 'user')
@@ -352,6 +352,15 @@ class TestActionLibBolt(BoltBaseActionTestCase):
         self.assert_remove_option(options, '--private-key', 'private_key')
         self.assert_remove_option(options, '--run-as', 'run_as')
         self.assert_remove_option(options, '--sudo-password', 'sudo_password')
+        self.assertEquals(options, [])
+
+    def test_build_options_args_ensure_unknown_args_cast_to_strings(self):
+        action = self.get_action_instance({})
+        options, args = action.build_options_args(
+            unknown_bool=True,
+            unknown_int=123,
+        )
+        self.assertEquals(args, ['True', '123'])
         self.assertEquals(options, [])
 
     @mock.patch('lib.bolt.sys')


### PR DESCRIPTION
* Fix bug where non-string parameters such as `connection_timeout` and `concurrency` were
  causing errors when running the `bolt` command. Non-string parameters will now be
  cast to a string so that the command invocation library can handle them properly.
